### PR TITLE
Remove pull request and push to main triggers for smoketest

### DIFF
--- a/.github/workflows/selfhost_smoketest.yml
+++ b/.github/workflows/selfhost_smoketest.yml
@@ -1,12 +1,6 @@
 name: 'Self-Hosted Smoke Tests'
 
 on:
-  push:
-    branches:
-      - 'main'
-  pull_request:
-    branches:
-      - 'main'
   workflow_dispatch:
   workflow_run:
     # Run this workflow after either of the other build/deploys run.


### PR DESCRIPTION
This job already gets triggered after build_runner and build_workflow which get pushed when merged to main.

There is a bootstrapping issue. If you run on a PR, it will run on the version that is in main, rather than the PR, so your fix could be blocked by the bug its trying to fix. You need to build and push the new revision before you run the smoketest.