### PR TITLE
Install file to make shell linter work

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -70,6 +70,7 @@ RUN apt-get update \
       ca-certificates \
       coreutils \
       curl \
+      file \
       git \
       git-lfs \
       gosu \


### PR DESCRIPTION
Shell linter is failing on self hosted runners due to missing the `file` binary