### PR TITLE
Fix script for running locally, improve privlidged mode detection

### DIFF
--- a/test_local.sh
+++ b/test_local.sh
@@ -10,19 +10,24 @@ RUNNER_NAME="local-$(tr -dc A-Za-z0-9 </dev/urandom | head -c 12 || true)"
 echo "Generating JIT Config. If no more output, something failed. Try running \
 command without storing to variable to see output."
 
+#shellcheck disable=SC1091 # local.env should not be checked in
+if [[ -f env/local.env ]]; then
+  set -o allexport
+  source env/local.env
+  set +o allexport
+fi
+
+# shellcheck disable=2154 # referenced vars are env vars
 # Generate JIT Config
 JIT_CONFIG="$(
     go run ./cmd/generate-jit \
-        -app-id \
-        -private-key \
-        -org \
+        -app-id "${GH_APP_ID}" \
+        -private-key "${GH_APP_PEM_PATH}" \
+        -org "${GH_ORG_NAME}" \
         -runner-name "${RUNNER_NAME}" \
-        -runner-group-id 1 #YOUR_APP_ID_GOES_HERE \
-    #PATH_TO_PEM_FILE \
-    #YOUR_ORG_NAME_GOES_HERE \
+        -runner-group-id 1 \
+        | gzip | base64
 )"
-
-echo "${JIT_CONFIG}"
 
 echo "I haven't found a way to make it interruptable once the runner is \
 listening. Use docker ps and docker kill in another terminal window."


### PR DESCRIPTION
Testing for /dev/sda or /dev/vda isn't a reliable check to see if in docker privileged mode, some environments (such as those with NVME SSDs).

Local runner testing script updated to include the gzipped JIT_CONFIG and accept inputs from a .env file.