### PR TITLE
Cleanup webhook code

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -317,7 +317,7 @@ jobs:
             --id-token "${{ steps.auth.outputs.id_token }}" \
             --payload-file "valid_payload.json" \
             --signature "bad-signature" \
-            --expect-http-status 500 \
+            --expect-http-status 400 \
             --expect-no-build
 
       - name: 'Run Webhook Tester (Malformed JSON)'
@@ -334,7 +334,7 @@ jobs:
             --run-id "${{ github.run_id }}" \
             --id-token "${{ steps.auth.outputs.id_token }}" \
             --payload-file "payload.json" \
-            --expect-http-status 200 \
+            --expect-http-status 400 \
             --expect-no-build
 
       - name: 'Run Webhook Tester (Missing Required Field)'

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -17,7 +17,9 @@ package webhook
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"html"
 	"log/slog"
@@ -65,6 +67,170 @@ func (s *Server) handleWebhook() http.Handler {
 	})
 }
 
+func (s *Server) processRequest(r *http.Request) *apiResponse {
+	ctx := r.Context()
+	logger := logging.FromContext(ctx)
+
+	event, err := validateGitHubPayload(r, s.webhookSecret)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to validate github payload", "error", err)
+		return &apiResponse{http.StatusBadRequest, "failed to validate github payload", err}
+	}
+
+	jobID, attributes := extractLoggedAttributes(event)
+	logger = logger.With(attributes...)
+	// Add to context so attributes are propagated down the stack.
+	ctx = logging.WithLogger(ctx, logger)
+
+	switch *event.Action {
+	case "queued":
+		return s.handleQueuedEvent(ctx, event, jobID)
+
+	case "in_progress":
+		if event.WorkflowJob.CreatedAt != nil && event.WorkflowJob.StartedAt != nil {
+			queuedDuration := event.WorkflowJob.StartedAt.Sub(event.WorkflowJob.CreatedAt.Time)
+			logger = logger.With("duration_queued_seconds", queuedDuration.Seconds())
+		}
+
+		logger.InfoContext(ctx, "Workflow job in progress")
+		return &apiResponse{http.StatusOK, "workflow job in progress event logged", nil}
+
+	case "completed":
+		logger.InfoContext(ctx, "Workflow job completed", extractCompletedLogAttributes(event)...)
+		return &apiResponse{http.StatusOK, "workflow job completed event logged", nil}
+
+	default:
+		// Log other unhandled workflow job actions
+		logger.InfoContext(ctx, "no action taken for unhandled workflow job action type", "action", *event.Action)
+		return &apiResponse{http.StatusOK, fmt.Sprintf("no action taken for action type: %q", *event.Action), nil}
+	}
+}
+
+func validateGitHubPayload(r *http.Request, webhookSecret []byte) (*github.WorkflowJobEvent, error) {
+	payload, err := github.ValidatePayload(r, webhookSecret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to validate payload: %w", err)
+	}
+
+	rawEvent, err := github.ParseWebHook(github.WebHookType(r), payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse webhook: %w", err)
+	}
+
+	event, ok := rawEvent.(*github.WorkflowJobEvent)
+	if !ok {
+		return nil, fmt.Errorf("unexpected event type dispatched from webhook, event type: %T", rawEvent)
+	}
+
+	// Validate event object
+	var merr error
+	if event.Action == nil {
+		merr = errors.Join(merr, fmt.Errorf("event is missing required field: action"))
+	}
+
+	// A workflow job is required for all actions.
+	if event.WorkflowJob == nil {
+		merr = errors.Join(merr, fmt.Errorf("event is missing required field: workflow_job"))
+	}
+	if merr != nil {
+		return nil, merr
+	}
+	return event, nil
+}
+
+func (s *Server) handleQueuedEvent(ctx context.Context, event *github.WorkflowJobEvent, jobID string) *apiResponse {
+	logger := logging.FromContext(ctx)
+	logger.InfoContext(ctx, "Workflow job queued")
+
+	if !slices.Contains(event.WorkflowJob.Labels, defaultRunnerLabel) {
+		logger.WarnContext(ctx, "no action taken for labels", "labels", event.WorkflowJob.Labels)
+		return &apiResponse{http.StatusOK, fmt.Sprintf("no action taken for labels: %s", event.WorkflowJob.Labels), nil}
+	}
+
+	imageTag := s.runnerImageTag
+	if s.environment == "autopush" {
+		for _, label := range event.WorkflowJob.Labels {
+			if strings.HasPrefix(label, "pr-") {
+				imageTag = label
+				break
+			}
+		}
+	}
+
+	if event.Installation == nil || event.Installation.ID == nil || event.Org == nil || event.Org.Login == nil || event.Repo == nil || event.Repo.Name == nil {
+		err := fmt.Errorf("event is missing required fields (installation, org, or repo)")
+		logger.ErrorContext(ctx, "cannot generate JIT config due to missing event data", "error", err)
+		return &apiResponse{http.StatusBadRequest, "unexpected event payload struture", err}
+	}
+
+	runnerID := fmt.Sprintf("GCP-%s", jobID)
+	logger = logger.With("runner_id", runnerID)
+	ctx = logging.WithLogger(ctx, logger)
+
+	responseText, err := s.startGitHubRunner(ctx, event, runnerID, logger, imageTag)
+	if err != nil {
+		return &apiResponse{http.StatusInternalServerError, responseText, err}
+	}
+
+	logger.InfoContext(ctx, runnerStartedMsg, slog.Any(githubWebhookEventKey, event))
+
+	return &apiResponse{http.StatusOK, runnerStartedMsg, nil}
+}
+
+func extractLoggedAttributes(event *github.WorkflowJobEvent) (string, []any) {
+	// Common attributes to always include for WorkflowJobEvent
+	var jobID, runID, jobName string
+	if event.WorkflowJob.ID != nil {
+		jobID = fmt.Sprintf("%d", *event.WorkflowJob.ID)
+	}
+	if event.WorkflowJob.RunID != nil {
+		runID = fmt.Sprintf("%d", *event.WorkflowJob.RunID)
+	}
+	if event.WorkflowJob.Name != nil {
+		jobName = *event.WorkflowJob.Name
+	}
+
+	// Base log fields that will be common to most WorkflowJob logs
+	attributes := []any{
+		"action_event_name", *event.Action,
+		"gh_run_id", runID,
+		"gh_job_id", jobID,
+		"gh_job_name", jobName,
+		"job_id", jobID,
+	}
+
+	// Add all available timestamps to logger attributes (they might be nil depending on event action)
+	if event.WorkflowJob.CreatedAt != nil {
+		attributes = append(attributes, "created_at", getTimeString(event.WorkflowJob.CreatedAt))
+	}
+	if event.WorkflowJob.StartedAt != nil {
+		attributes = append(attributes, "started_at", getTimeString(event.WorkflowJob.StartedAt))
+	}
+	if event.WorkflowJob.CompletedAt != nil {
+		attributes = append(attributes, "completed_at", getTimeString(event.WorkflowJob.CompletedAt))
+	}
+	return jobID, attributes
+}
+
+func extractCompletedLogAttributes(event *github.WorkflowJobEvent) []any {
+	var completedAttributes []any
+	if event.WorkflowJob.Conclusion != nil {
+		completedAttributes = append(completedAttributes, "conclusion", *event.WorkflowJob.Conclusion)
+	}
+
+	if event.WorkflowJob.StartedAt != nil && event.WorkflowJob.CompletedAt != nil {
+		inProgressDuration := event.WorkflowJob.CompletedAt.Sub(event.WorkflowJob.StartedAt.Time)
+		completedAttributes = append(completedAttributes, "duration_in_progress_seconds", inProgressDuration.Seconds())
+	}
+
+	// Optional: Also log total duration from creation to completion here
+	if event.WorkflowJob.CreatedAt != nil && event.WorkflowJob.CompletedAt != nil {
+		totalDuration := event.WorkflowJob.CompletedAt.Sub(event.WorkflowJob.CreatedAt.Time)
+		completedAttributes = append(completedAttributes, "duration_total_seconds", totalDuration.Seconds())
+	}
+	return completedAttributes
+}
+
 func compressAndBase64EncodeString(input string) (string, error) {
 	var compressedJIT bytes.Buffer
 	gzipWriter, err := gzip.NewWriterLevel(&compressedJIT, gzip.BestCompression)
@@ -82,204 +248,68 @@ func compressAndBase64EncodeString(input string) (string, error) {
 	return base64.StdEncoding.EncodeToString(compressedJIT.Bytes()), nil
 }
 
-func (s *Server) processRequest(r *http.Request) *apiResponse {
-	ctx := r.Context()
-	logger := logging.FromContext(ctx)
-
-	payload, err := github.ValidatePayload(r, s.webhookSecret)
+func (s *Server) startGitHubRunner(ctx context.Context, event *github.WorkflowJobEvent, runnerID string, logger *slog.Logger, imageTag string) (string, error) {
+	jitConfig, err := s.GenerateRepoJITConfig(ctx, *event.Installation.ID, *event.Org.Login, *event.Repo.Name, runnerID)
 	if err != nil {
-		return &apiResponse{http.StatusInternalServerError, "failed to validate payload", err}
+		logger.ErrorContext(ctx, "failed to generate JIT config",
+			"error", err.Error(),
+		)
+		return "error generating jitconfig", err
 	}
 
-	event, err := github.ParseWebHook(github.WebHookType(r), payload)
+	// Sometimes JITConfig has exceeded the 4,000-character limit for
+	// substitutions. It has nested base64 encoded data, so it is very
+	// compressible.
+	compressedJIT, err := compressAndBase64EncodeString(*jitConfig.EncodedJITConfig)
 	if err != nil {
-		return &apiResponse{http.StatusInternalServerError, "failed to parse webhook", err}
+		return "failed to compress JIT config", err
 	}
 
-	switch event := event.(type) {
-	case *github.WorkflowJobEvent:
-		// Check for nil action first to avoid nil pointer dereference
-		if event.Action == nil {
-			logger.InfoContext(ctx, "no action taken for nil action type")
-			return &apiResponse{http.StatusOK, "no action taken for nil action type", nil}
-		}
-
-		// A workflow job is required for all actions.
-		if event.WorkflowJob == nil {
-			err := fmt.Errorf("event is missing required field: workflow_job")
-			logger.ErrorContext(ctx, "cannot process event due to missing workflow_job", "error", err)
-			return &apiResponse{http.StatusBadRequest, "unexpected event payload structure", err}
-		}
-
-		// Common attributes to always include for WorkflowJobEvent
-		var jobID, runID, jobName string
-		if event.WorkflowJob.ID != nil {
-			jobID = fmt.Sprintf("%d", *event.WorkflowJob.ID)
-		}
-		if event.WorkflowJob.RunID != nil {
-			runID = fmt.Sprintf("%d", *event.WorkflowJob.RunID)
-		}
-		if event.WorkflowJob.Name != nil {
-			jobName = *event.WorkflowJob.Name
-		}
-
-		runnerID := fmt.Sprintf("GCP-%s", jobID)
-
-		// Base log fields that will be common to most WorkflowJob logs
-		baseLogFields := []any{
-			"action_event_name", *event.Action,
-			"gh_run_id", runID,
-			"gh_job_id", jobID,
-			"gh_job_name", jobName,
-			"job_id", jobID,
-			"runner_id", runnerID,
-		}
-
-		// Add all available timestamps to base log fields (they might be nil depending on event action)
-		if event.WorkflowJob.CreatedAt != nil {
-			baseLogFields = append(baseLogFields, "created_at", getTimeString(event.WorkflowJob.CreatedAt))
-		}
-		if event.WorkflowJob.StartedAt != nil {
-			baseLogFields = append(baseLogFields, "started_at", getTimeString(event.WorkflowJob.StartedAt))
-		}
-		if event.WorkflowJob.CompletedAt != nil {
-			baseLogFields = append(baseLogFields, "completed_at", getTimeString(event.WorkflowJob.CompletedAt))
-		}
-
-		switch *event.Action {
-		case "queued":
-			logger.InfoContext(ctx, "Workflow job queued", baseLogFields...)
-
-			if !slices.Contains(event.WorkflowJob.Labels, defaultRunnerLabel) {
-				logger.WarnContext(ctx, "no action taken for labels", append(baseLogFields, "labels", event.WorkflowJob.Labels)...)
-				return &apiResponse{http.StatusOK, fmt.Sprintf("no action taken for labels: %s", event.WorkflowJob.Labels), nil}
-			}
-
-			imageTag := s.runnerImageTag
-			if s.environment == "autopush" {
-				for _, label := range event.WorkflowJob.Labels {
-					if strings.HasPrefix(label, "pr-") {
-						imageTag = label
-						break
-					}
-				}
-			}
-
-			if event.Installation == nil || event.Installation.ID == nil || event.Org == nil || event.Org.Login == nil || event.Repo == nil || event.Repo.Name == nil {
-				err := fmt.Errorf("event is missing required fields (installation, org, or repo)")
-				logger.ErrorContext(ctx, "cannot generate JIT config due to missing event data", append(baseLogFields, "error", err)...)
-				return &apiResponse{http.StatusBadRequest, "unexpected event payload struture", err}
-			}
-
-			jitConfig, errResponse := s.GenerateRepoJITConfig(ctx, *event.Installation.ID, *event.Org.Login, *event.Repo.Name, runnerID)
-			if errResponse != nil {
-				logger.ErrorContext(ctx, "failed to generate JIT config", append(baseLogFields, "error", errResponse.Error, "response_message", errResponse.Message)...)
-				return errResponse
-			}
-
-			// Sometimes JITConfig has exceeded the 4,000-character limit for
-			// substitutions. It has nested base64 encoded data, so it is very
-			// compressible.
-			compressedJIT, err := compressAndBase64EncodeString(*jitConfig.EncodedJITConfig)
-			if err != nil {
-				return &apiResponse{http.StatusInternalServerError, "failed to compress JIT config", err}
-			}
-
-			build := &cloudbuildpb.Build{
-				ServiceAccount: s.runnerServiceAccount,
-				Steps: []*cloudbuildpb.BuildStep{
-					{
-						Id:   "run",
-						Name: "$_REPOSITORY_ID/$_IMAGE_NAME:$_IMAGE_TAG",
-						Env: []string{
-							"ENCODED_JIT_CONFIG=${_ENCODED_JIT_CONFIG}",
-						},
-					},
+	build := &cloudbuildpb.Build{
+		ServiceAccount: s.runnerServiceAccount,
+		Steps: []*cloudbuildpb.BuildStep{
+			{
+				Id:   "run",
+				Name: "$_REPOSITORY_ID/$_IMAGE_NAME:$_IMAGE_TAG",
+				Env: []string{
+					"ENCODED_JIT_CONFIG=${_ENCODED_JIT_CONFIG}",
 				},
-				Options: &cloudbuildpb.BuildOptions{
-					Logging: cloudbuildpb.BuildOptions_CLOUD_LOGGING_ONLY,
-				},
-				Substitutions: map[string]string{
-					"_ENCODED_JIT_CONFIG": compressedJIT,
-					"_REPOSITORY_ID":      s.runnerRepositoryID,
-					"_IMAGE_NAME":         s.runnerImageName,
-					"_IMAGE_TAG":          imageTag,
-				},
-			}
-
-			// Check if this is an E2E test run and add appropriate tags.
-			if s.e2eTestRunID != "" {
-				build.Tags = []string{"e2e-test", fmt.Sprintf("e2e-run-id-%s", s.e2eTestRunID)}
-			}
-
-			if s.runnerWorkerPoolID != "" {
-				build.Options.Pool = &cloudbuildpb.BuildOptions_PoolOption{
-					Name: s.runnerWorkerPoolID,
-				}
-			}
-
-			buildReq := &cloudbuildpb.CreateBuildRequest{
-				Parent:    fmt.Sprintf("projects/%s/locations/%s", s.runnerProjectID, s.runnerLocation),
-				ProjectId: s.runnerProjectID,
-				Build:     build,
-			}
-
-			if err := s.cbc.CreateBuild(ctx, buildReq); err != nil {
-				logger.ErrorContext(ctx, "failed to run Cloud Build for runner", append(baseLogFields, "error", err)...)
-				return &apiResponse{http.StatusInternalServerError, "failed to run build", err}
-			}
-
-			logger.InfoContext(ctx, runnerStartedMsg, slog.Any(githubWebhookEventKey, event))
-			return &apiResponse{http.StatusOK, runnerStartedMsg, nil}
-
-		case "in_progress":
-			// Calculate and log "queued duration"
-			logFields := append([]any{}, baseLogFields...) // Create a mutable copy
-
-			if event.WorkflowJob.CreatedAt != nil && event.WorkflowJob.StartedAt != nil {
-				queuedDuration := event.WorkflowJob.StartedAt.Sub(event.WorkflowJob.CreatedAt.Time)
-
-				logFields = append(logFields, "duration_queued_seconds", queuedDuration.Seconds())
-			}
-
-			logger.InfoContext(ctx, "Workflow job in progress", logFields...)
-			return &apiResponse{http.StatusOK, "workflow job in progress event logged", nil}
-
-		case "completed":
-			// Calculate and log "in progress duration"
-			logFields := append([]any{}, baseLogFields...) // Create a mutable copy
-
-			if event.WorkflowJob.Conclusion != nil {
-				logFields = append(logFields, "conclusion", *event.WorkflowJob.Conclusion)
-			}
-
-			if event.WorkflowJob.StartedAt != nil && event.WorkflowJob.CompletedAt != nil {
-				inProgressDuration := event.WorkflowJob.CompletedAt.Sub(event.WorkflowJob.StartedAt.Time)
-				logFields = append(logFields, "duration_in_progress_seconds", inProgressDuration.Seconds())
-			}
-
-			// Optional: Also log total duration from creation to completion here
-			if event.WorkflowJob.CreatedAt != nil && event.WorkflowJob.CompletedAt != nil {
-				totalDuration := event.WorkflowJob.CompletedAt.Sub(event.WorkflowJob.CreatedAt.Time)
-				logFields = append(logFields, "duration_total_seconds", totalDuration.Seconds())
-			}
-
-			logger.InfoContext(ctx, "Workflow job completed", logFields...)
-			return &apiResponse{http.StatusOK, "workflow job completed event logged", nil}
-
-		default:
-			// Log other unhandled workflow job actions
-			logger.InfoContext(ctx, "no action taken for unhandled workflow job action type", append(baseLogFields, "action", *event.Action)...)
-			return &apiResponse{http.StatusOK, fmt.Sprintf("no action taken for action type: %q", *event.Action), nil}
-		}
-
-	default:
-		// Log other unhandled webhook event types
-		logger.ErrorContext(ctx, "Received unhandled event type",
-			"event_type", fmt.Sprintf("%T", event),
-			"payload", string(payload))
-		return &apiResponse{http.StatusInternalServerError, "unexpected event type dispatched from webhook", fmt.Errorf("event type: %T", event)}
+			},
+		},
+		Options: &cloudbuildpb.BuildOptions{
+			Logging: cloudbuildpb.BuildOptions_CLOUD_LOGGING_ONLY,
+		},
+		Substitutions: map[string]string{
+			"_ENCODED_JIT_CONFIG": compressedJIT,
+			"_REPOSITORY_ID":      s.runnerRepositoryID,
+			"_IMAGE_NAME":         s.runnerImageName,
+			"_IMAGE_TAG":          imageTag,
+		},
 	}
+
+	// Check if this is an E2E test run and add appropriate tags.
+	if s.e2eTestRunID != "" {
+		build.Tags = []string{"e2e-test", fmt.Sprintf("e2e-run-id-%s", s.e2eTestRunID)}
+	}
+
+	if s.runnerWorkerPoolID != "" {
+		build.Options.Pool = &cloudbuildpb.BuildOptions_PoolOption{
+			Name: s.runnerWorkerPoolID,
+		}
+	}
+
+	buildReq := &cloudbuildpb.CreateBuildRequest{
+		Parent:    fmt.Sprintf("projects/%s/locations/%s", s.runnerProjectID, s.runnerLocation),
+		ProjectId: s.runnerProjectID,
+		Build:     build,
+	}
+
+	if err := s.cbc.CreateBuild(ctx, buildReq); err != nil {
+		err = fmt.Errorf("failed to create cloud run build: %w", err)
+		logger.ErrorContext(ctx, "cloud run build failed", "error", err)
+		return "failed to create build", err
+	}
+	return "", nil
 }
 
 // getTimeString is a helper function to format a *github.Timestamp pointer into an ISO 8601 string.


### PR DESCRIPTION
- Use logger.With() rather than appending a set of common log lines to every call of log
- Remove a switch with a single case + default to an if statement to reduce cyclomatic complexity
- Decompose `Server.processRequest()` as it was over 200 lines.
- Changed http response on some invalid payloads (5xx -> 400, 200 -> 400)