### PR TITLE
Ensure externals folder is copied over in the custom runner image

### DIFF
--- a/runner/Dockerfile
+++ b/runner/Dockerfile
@@ -96,6 +96,10 @@ RUN curl -f -L -o runner.tar.gz https://github.com/actions/runner/releases/downl
     && rm runner.tar.gz \
     && rm -rf /var/lib/apt/lists/*
 
+# Ensure externals are available for ARC to use this custom image
+RUN mkdir -p /home/runner/externals/ \
+    && cp -r /actions-runner/externals/. /home/runner/externals/    
+
 # Copy pre-run script and add it to actions runner config file
 COPY pre-run.sh /actions-runner/pre-run.sh
 RUN chmod +x /actions-runner/pre-run.sh \


### PR DESCRIPTION
In an attempt to replace the github runner image with the custom one in the ARC infrastructure, it was discovered that we must have the externals folder available in the custom runner image.

There is an init container when running in `dind` mode that expects the contents of this folder to be available. 