### PR TITLE
feat(runner): Gracefully handle idle runner timeouts

### DIFF
--- a/runner/start_runner.sh
+++ b/runner/start_runner.sh
@@ -28,9 +28,22 @@ echo "Runner started with PID ${RUNNER_PID}. Idle timeout is ${IDLE_TIMEOUT_SECO
 KILLER_PID=$!
 
 # Wait for the runner to complete a job and exit.
-wait "${RUNNER_PID}"
+EXIT_CODE=0
+wait "${RUNNER_PID}" || EXIT_CODE=$?
 
 # If the runner exits, it means it ran a job, so we don't need the killer process anymore.
-kill "${KILLER_PID}"
+# It's possible the killer process has already exited (in the timeout case),
+# so we add `|| true` to prevent `set -e` from failing the script.
+kill "${KILLER_PID}" || true
 # Clean up the lock file on exit
 rm -f "${LOCK_FILE}"
+
+# Exit with a success code if the runner was terminated by the idle timeout.
+# Exit code 143 corresponds to SIGTERM.
+if [[ "${EXIT_CODE}" == "143" || "${EXIT_CODE}" == "0" ]]; then
+  echo "Runner exited with code ${EXIT_CODE}. Assuming success."
+  exit 0
+else
+  echo "Runner exited with unexpected code ${EXIT_CODE}. Failing."
+  exit "${EXIT_CODE}"
+fi


### PR DESCRIPTION
This PR addresses the issue where idle self-hosted runners, when terminated after a 5-minute timeout, caused Google Cloud Build (GCB) jobs to fail. The  script has been modified to gracefully handle these timeouts.

Specifically, the script now checks the exit code of the runner process. If the runner exits with code 143 (indicating a SIGTERM, typically from the idle timeout) or 0 (successful completion), the script will now exit with a success code (0). This prevents GCB jobs from failing due to expected idle timeouts.

For any other non-zero exit codes, the script will continue to fail, ensuring that actual anomalous runner terminations are still reported as failures.