### PR TITLE
remove runner project id requirement

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -151,11 +151,7 @@ variable "kms_key_version" {
 variable "runner_project_ids" {
   description = "The project IDs to be used as a runner."
   type        = list(string)
-
-  validation {
-    condition     = length(var.runner_project_ids) == 1 && var.runner_project_ids[0] != ""
-    error_message = "Exactly one runner project must be specified."
-  }
+  default     = []
 }
 
 variable "region" {


### PR DESCRIPTION
Begin to loosen the tight coupling between the dispatcher and runners