### PR TITLE
fix: always run smoke-tests-passed job when in merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
   smoke-tests-passed:
     needs: ['deploy', 'smoke-tests']
     if: |-
-      ${{ github.event_name == 'merge_group' }}
+      ${{ always() && github.event_name == 'merge_group' }}
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Check Deployment and Tests Status'


### PR DESCRIPTION
This will ensure the `smoke-tests-passed` status check is verified.